### PR TITLE
Update unified_decoder.js Chirpstack v4 Wrapper

### DIFF
--- a/console-decoders/unified_decoder.js
+++ b/console-decoders/unified_decoder.js
@@ -61,3 +61,10 @@ function Decoder(bytes, port) {
 
   return decoded;
 }
+
+// Wrapper for ChirpStack V4:
+function decodeUplink(input) {
+  return { 
+      data: Decoder(input.bytes, input.fPort)
+  };   
+}


### PR DESCRIPTION
Missing Chirpstack v4 Wrapper. Without this, the Chirpstack dashboard would report an error on decode, and no 'object's would be decoded.